### PR TITLE
fix: replace deprecated event with lifespan

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -24,6 +24,9 @@ class DiscordAuth:
     async def setup(self):
         self.session = aiohttp.ClientSession()
 
+    async def close(self):
+        await self.session.close()
+
     async def get_user(self, token):
         headers = {"Authorization": f"Bearer {token}"}
         async with self.session.get(API_ENDPOINT + "/users/@me", headers=headers) as response:

--- a/main.py
+++ b/main.py
@@ -22,13 +22,14 @@ INVITE_LINK = ""
 async def on_startup(app: FastAPI):
     await api.setup()
     await db.setup()
+    await feature_db.setup()
 
     yield
 
     await api.close()
     # Hier kann noch selbst eine Methode, die je nach Datenbank variiert, hinzugefügt werden, um die Datenbank zu "schließen"
 
-app = FastAPI()
+app = FastAPI(lifespan=on_startup)
 app.mount("/static", StaticFiles(directory="frontend/static"), name="static")
 templates = Jinja2Templates(directory="frontend")
 

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from fastapi import Cookie, FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
-
+from contextlib import asynccontextmanager
 from backend import DiscordAuth, db, feature_db
 
 # Hier die Daten aus dem Developer-Portal einfügen
@@ -18,6 +18,15 @@ REDIRECT_URI = "http://localhost:8000/callback"
 LOGIN_URL = ""
 INVITE_LINK = ""
 
+@asynccontextmanager
+async def on_startup(app: FastAPI):
+    await api.setup()
+    await db.setup()
+
+    yield
+
+    await api.close()
+    # Hier kann noch selbst eine Methode, die je nach Datenbank variiert, hinzugefügt werden, um die Datenbank zu "schließen"
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="frontend/static"), name="static")
@@ -25,13 +34,6 @@ templates = Jinja2Templates(directory="frontend")
 
 ipc = Client(secret_key="keks")
 api = DiscordAuth(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI)
-
-
-@app.on_event("startup")
-async def on_startup():
-    await api.setup()
-    await db.setup()
-    await feature_db.setup()
 
 
 @app.get("/")


### PR DESCRIPTION
Depricated-Event entfernt und mit einem contextmanager ersetzt. Mehr Informationen dazu: https://fastapi.tiangolo.com/advanced/events/